### PR TITLE
Enter user/pass once

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,9 +3,7 @@ the observing program from the obscat, and compute percentages of
 time and proposals selected in various ways in the various instrument
 configurations (ACIS-I, ACIS-S, HRC-I, HRC-S; and HETG, LETG, NONE).
 
-Ah. Note that the cool targets are not represented in the outputs.
-
-Here's what you do.
+Here's what you do:
 
 [1] Copy the files in this directory into a new directory labeled with the
 date. Edit the list of AO periods at the top (it's in there twice, in
@@ -16,15 +14,14 @@ the *text.html files to say what you did for each. Create new *text files
 as needed, but be sure the lists in the foreach() statements and copies
 at the end in the script cover if new ones are added.
 
-[2] Run the script make_stats.csh. Be prepared to give your archive username
-and password many times. I'm sure there's a way to consolidate that...
+[2] Run the script make_stats.csh. You will need to give your archive username
+and password at the beginning.
 
 [3] The script tars up the resulting web pages and copies them to
 the ACIS temporary web space. If you expand them there, you can see
 the pages in a path like this one:
 
 http://cxc.harvard.edu/acis/tmp/observing_stats/
-
 
 This script makes extensive use of the RDB tools provided by Diab Jerius.
 

--- a/make_stats.csh
+++ b/make_stats.csh
@@ -1,7 +1,14 @@
 #!/usr/bin/env tcsh
 
+echo -n "Username: "
+set username = $<
+stty -echo 
+echo -n "Password: "
+set password = $<
+stty echo
+
 # get ASCDS tools (sqsh, param_extract)
-source ~/.ascrc
+source /home/ascds/DS.release/config/system/.ascrc
 # get rdb tools
 source /proj/axaf/simul/etc/mst_envs.tcsh
 
@@ -41,9 +48,9 @@ rm -f obscat_acis_?? obscat_hrc_?? *remarks *winparams *abstracts
 foreach ao ( $aolist )
 
    echo param_extract -a -A $ao -b -o obscat_acis_${ao}
-   param_extract -a -A $ao -b -o obscat_acis_${ao} >! obscat_acis_${ao}.log
+   echo "$username\n$password" | param_extract -a -A $ao -b -o obscat_acis_${ao} >! obscat_acis_${ao}.log
    echo param_extract -h -A $ao -b -o obscat_hrc_${ao} 
-   param_extract -h -A $ao -b -o obscat_hrc_${ao} >! obscat_hrc_${ao}.log
+   echo "$username\n$password" | param_extract -h -A $ao -b -o obscat_hrc_${ao} >! obscat_hrc_${ao}.log
 
 end
 rm -f *remarks *winparams *abstracts
@@ -52,7 +59,7 @@ date +%D >! date_extracted.txt
 
 # now go use sqsh to get the hrc parameters to file hrc_test
 #
-/usr/local/bin/sqsh -S ocatsqlsrv -Uedgar -w 400 < hrc_extract.sqsh >! hrc_obscat_test.txt
+/usr/local/bin/sqsh -S ocatsqlsrv -U "$username" -P "$password" -w 400 < hrc_extract.sqsh >! hrc_obscat_test.txt
 
 # endif
 # end of obscat extraction; comment out if the 'if (0) then' line is commented out.


### PR DESCRIPTION
This PR allows for entering the username and password to the OCAT once and then passes it to the invocations of `param_extract` and `sqsh`.

It also changes the source of the `.ascrc` file to the DS ops location.